### PR TITLE
Class and initialization refactoring to simplify things

### DIFF
--- a/runtime.py
+++ b/runtime.py
@@ -456,25 +456,15 @@ def run_worker(model_name, rank, world_size, num_split):
     # Higher timeout is added to accommodate for kernel compilation time in case of ROCm.
     options = rpc.TensorPipeRpcBackendOptions(num_worker_threads=num_worker_threads,rpc_timeout=3000)
 
-
+    rpc.init_rpc(
+        f"worker{rank}",
+        rank=rank,
+#         backend=rpc.BackendType.PROCESS_GROUP,
+        world_size=world_size,
+        rpc_backend_options=options
+    )
     if rank == 0:
-        rpc.init_rpc(
-            "worker0",
-            rank=rank,
-   #         backend=rpc.BackendType.PROCESS_GROUP,
-            world_size=world_size,
-            rpc_backend_options=options
-        )
         run_master(model_name, world_size, num_split)
-    else:
-        rpc.init_rpc(
-            f"worker{rank}",
-            rank=rank,
-   #         backend=rpc.BackendType.PROCESS_GROUP,
-            world_size=world_size,
-            rpc_backend_options=options
-        )
-        pass
 
     # block until all rpcs finisha
     rpc.shutdown()


### PR DESCRIPTION
The primary code contribution here is the elimination of the `TransformerShardCls` subclass.  It's not necessary to dynamically generate classes each with a different `qualname`, and I found it pretty confusing the way it was.  Please let me know if I've overlooked a reason for that design though.

I eliminated the use of some global variables which were sometimes used globally and other times passed around as parameters.  The latter is generally preferable.  Additional work can still be done to further reduce global var usage.

Finally, the worker initialization is simplified by avoiding some code duplication.

Good work on adding the command line argument parsing - I think it definitely makes this code easier to use.